### PR TITLE
feat: add Ctrl+C support for script termination

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ from modules.ui import Notification
 import pyperclip
 import sys
 import subprocess
+import signal
 
 # --- Configuration ---
 DOUBLE_PRESS_INTERVAL = 0.3  # Seconds
@@ -23,10 +24,45 @@ is_recording = False
 audio_frames = []
 listener_thread = None
 notification = None
+keyboard_listener = None
+shutdown_requested = False
+shutdown_in_progress = False
 
 
 def get_timestamp_str():
     return time.strftime("%Y%m%d_%H%M%S")
+
+
+def signal_handler(sig, frame):
+    """Handles Ctrl+C (SIGINT) signal for graceful shutdown."""
+    global \
+        shutdown_requested, \
+        is_recording, \
+        keyboard_listener, \
+        notification, \
+        shutdown_in_progress
+
+    # Prevent double execution
+    if shutdown_in_progress:
+        return
+    shutdown_in_progress = True
+
+    print("\nShutting down...")
+    shutdown_requested = True
+
+    # Stop recording if active
+    if is_recording:
+        stop_recording()
+
+    # Stop keyboard listener
+    if keyboard_listener:
+        keyboard_listener.stop()
+
+    # Quit Qt application if it exists
+    if notification:
+        notification.quit()
+
+    sys.exit(0)
 
 
 def on_press(key):
@@ -144,20 +180,33 @@ def paste_text(text):
     print("Pasted: " + text)
 
 
+def check_shutdown_requested():
+    """Callback function for Qt to check if shutdown was requested."""
+    return shutdown_requested
+
+
 def main():
-    global notification
-    notification = Notification()
+    global notification, keyboard_listener
+
+    # Set up signal handler for Ctrl+C
+    signal.signal(signal.SIGINT, signal_handler)
+
+    notification = Notification(shutdown_callback=check_shutdown_requested)
 
     print("Application started.")
     print("Press Ctrl twice quickly to start recording.")
     print("Press Ctrl again to stop.")
+    print("Press Ctrl+C in the terminal to quit.")
 
-    with keyboard.Listener(on_press=on_press) as listener:
-        # The listener joining and the notification running are not mutually exclusive.
-        # We need the listener to run in a background thread and the UI to run in the main thread.
-        listener_thread = threading.Thread(target=listener.join)
-        listener_thread.start()
-        notification.run()
+    # Start keyboard listener in a separate thread
+    keyboard_listener = keyboard.Listener(on_press=on_press)
+    keyboard_listener.start()
+
+    try:
+        # Run Qt event loop in main thread - this is the proper way
+        notification.app.exec()
+    except KeyboardInterrupt:
+        signal_handler(signal.SIGINT, None)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -24,8 +24,10 @@ audio_frames = []
 listener_thread = None
 notification = None
 
+
 def get_timestamp_str():
     return time.strftime("%Y%m%d_%H%M%S")
+
 
 def on_press(key):
     global last_key_press_time, is_recording, audio_frames
@@ -44,16 +46,20 @@ def on_press(key):
     except Exception as e:
         print(f"An error occurred: {e}")
 
+
 def record_audio():
     global audio_frames
     audio_frames = []
-    with sd.InputStream(samplerate=SAMPLE_RATE, channels=CHANNELS, dtype='float32') as stream:
+    with sd.InputStream(
+        samplerate=SAMPLE_RATE, channels=CHANNELS, dtype="float32"
+    ) as stream:
         print("Recording started...")
         while is_recording:
             frames, overflowed = stream.read(FRAMES_PER_BUFFER)
             if overflowed:
                 print("Warning: input overflowed")
             audio_frames.append(frames)
+
 
 def start_recording():
     global is_recording, listener_thread
@@ -66,6 +72,7 @@ def start_recording():
     listener_thread = threading.Thread(target=record_audio)
     listener_thread.start()
 
+
 def stop_recording():
     global is_recording, listener_thread
     if not is_recording:
@@ -76,7 +83,7 @@ def stop_recording():
         notification.hide()
     is_recording = False
     if listener_thread:
-        listener_thread.join() # Wait for recording thread to finish
+        listener_thread.join()  # Wait for recording thread to finish
 
     if audio_frames:
         filename = OUTPUT_FILENAME_TEMPLATE
@@ -89,6 +96,7 @@ def stop_recording():
     else:
         print("No audio was recorded.")
 
+
 def paste_text(text):
     """Pastes the given text by copying it to clipboard and simulating a paste command."""
     pyperclip.copy(text)
@@ -98,12 +106,16 @@ def paste_text(text):
         success = False
         try:
             result = subprocess.run(
-                ["osascript", "-e", 'tell application "System Events" to keystroke "v" using command down'],
+                [
+                    "osascript",
+                    "-e",
+                    'tell application "System Events" to keystroke "v" using command down',
+                ],
                 capture_output=True,
                 text=True,
                 check=False,
             )
-            success = (result.returncode == 0)
+            success = result.returncode == 0
         except Exception:
             success = False
 
@@ -130,6 +142,7 @@ def paste_text(text):
             controller.release("v")
 
     print("Pasted: " + text)
+
 
 def main():
     global notification

--- a/modules/stt.py
+++ b/modules/stt.py
@@ -5,6 +5,7 @@ print("Loading voice recognition model (please wait)...")
 
 model = from_pretrained("mlx-community/parakeet-tdt-0.6b-v2")
 
+
 def transcribe(audio_file_path):
     result = model.transcribe(audio_file_path)
     return result.text


### PR DESCRIPTION
## Problem
I ran into some errors when unplugging my microphone that caused the script to not work properly until a restart. Pressing Ctrl+C when focused on the terminal did not work to stop the script -- leading to me needing to close the terminal and run the script in a new terminal in order to get things working again.

## Solution
I added Ctrl+C support so that the script can be restarted within less than a second. (Ctrl+C → ↑ → Enter)

## Changes
- Added signal handler for proper Ctrl+C support
- Qt timer coordination for clean shutdown
- Proper resource cleanup on exit

## Testing
- [x] Ctrl+C works to quit the script
- [x] Ctrl+C is only detected within the terminal
- [x] Previous behavior works the same